### PR TITLE
[FIXED] KeyboardLayout didn't get detected

### DIFF
--- a/DragonBurn/Features/Misc.h
+++ b/DragonBurn/Features/Misc.h
@@ -28,6 +28,8 @@ namespace Misc
 		QWERTY,
 		AZERTY,
 		QWERTZ,
+		COLEMAK,
+		DVORAK,
 		UNKNOWN
 	};
 
@@ -40,7 +42,9 @@ namespace Misc
 	static std::map<KeyboardLayout, KeyLayout> keyLayouts = {
 		{KeyboardLayout::QWERTY, {'W', 'S', 'A', 'D'}},
 		{KeyboardLayout::AZERTY, {'Z', 'S', 'Q', 'D'}},
-		{KeyboardLayout::QWERTZ, {'W', 'S', 'A', 'D'}}
+		{KeyboardLayout::QWERTZ, {'W', 'S', 'A', 'D'}},
+		{KeyboardLayout::COLEMAK, {'W', 'R', 'A', 'S'}},
+		{KeyboardLayout::DVORAK, {',', 'O', 'A', 'E'}}
 	};
 
 	inline bool Zoom = false;
@@ -156,7 +160,7 @@ namespace Misc
 	};
 
 	
-	static inline KeyboardLayout DetectKeyboardLayout()
+			static inline KeyboardLayout DetectKeyboardLayout()
 	{
 		char layoutName[KL_NAMELENGTH];
 		if (GetKeyboardLayoutNameA(layoutName))
@@ -164,23 +168,96 @@ namespace Misc
 			std::string sLayoutName(layoutName);
 			std::transform(sLayoutName.begin(), sLayoutName.end(), sLayoutName.begin(), ::toupper);
 
+			// QWERTY-based layouts
+			// This is a comprehensive list of layouts that are based on the QWERTY physical layout.
 			if (sLayoutName == "00000409" || sLayoutName == "00000809" ||
 				sLayoutName == "00001009" || sLayoutName == "00001809" ||
-				sLayoutName == "00004009" || sLayoutName == "00010409" ||
-				sLayoutName == "00020409" || sLayoutName == "00030409" ||
-				sLayoutName == "00040409" || sLayoutName == "00050409" ||
-				sLayoutName == "00000419" ||
-				sLayoutName == "00000422")
+				sLayoutName == "00004009" || sLayoutName == "00020409" ||
+				sLayoutName == "00050409" || sLayoutName == "00000419" ||
+				sLayoutName == "00000422" || sLayoutName == "0000041C" ||
+				sLayoutName == "00000401" || sLayoutName == "00010401" ||
+				sLayoutName == "0000042B" || sLayoutName == "00000423" ||
+				sLayoutName == "00010402" || sLayoutName == "00000804" ||
+				sLayoutName == "00000406" || sLayoutName == "00000413" ||
+				sLayoutName == "00000425" || sLayoutName == "0000040B" ||
+				sLayoutName == "00000408" || sLayoutName == "0000040D" ||
+				sLayoutName == "0000040F" || sLayoutName == "00000410" ||
+				sLayoutName == "00000411" || sLayoutName == "00000412" ||
+				sLayoutName == "00000426" || sLayoutName == "00000427" ||
+				sLayoutName == "00000414" || sLayoutName == "00000415" ||
+				sLayoutName == "00000416" || sLayoutName == "00000816" ||
+				sLayoutName == "00000418" || sLayoutName == "0000040A" ||
+				sLayoutName == "0000041D" || sLayoutName == "0000041F" ||
+				sLayoutName == "00140C00" || sLayoutName == "0000044D" ||
+				sLayoutName == "0000042C" || sLayoutName == "00000445" ||
+				sLayoutName == "0000045C" || sLayoutName == "00000404" ||
+				sLayoutName == "00000439" || sLayoutName == "00000438" ||
+				sLayoutName == "00020437" || sLayoutName == "00000468" ||
+				sLayoutName == "0000044B" || sLayoutName == "00000454" ||
+				sLayoutName == "0000042F" || sLayoutName == "00090C00" ||
+				sLayoutName == "00000448" || sLayoutName == "00000463" ||
+				sLayoutName == "00000485" || sLayoutName == "00030C00" ||
+				sLayoutName == "0000042A" || sLayoutName == "0000046D" ||
+				sLayoutName == "00000429" || sLayoutName == "0002042B" ||
+				sLayoutName == "0003042B" || sLayoutName == "0001042B" ||
+				sLayoutName == "0001042C" || sLayoutName == "00020445" ||
+				sLayoutName == "00010445" || sLayoutName == "00000813" ||
+				sLayoutName == "000B0C00" || sLayoutName == "00020402" ||
+				sLayoutName == "00040402" || sLayoutName == "00000402" ||
+				sLayoutName == "00011009" || sLayoutName == "0000085F" ||
+				sLayoutName == "0001045C" || sLayoutName == "00001004" ||
+				sLayoutName == "00000C04" || sLayoutName == "00001404" ||
+				sLayoutName == "00010405" || sLayoutName == "00020405" ||
+				sLayoutName == "00000437" || sLayoutName == "00010408" ||
+				sLayoutName == "00020408" || sLayoutName == "00030408" ||
+				sLayoutName == "0000046F" || sLayoutName == "00000447" ||
+				sLayoutName == "00010439" || sLayoutName == "00000470" ||
+				sLayoutName == "00000421" || sLayoutName == "0000085D" ||
+				sLayoutName == "0001045D" || sLayoutName == "0000043F" ||
+				sLayoutName == "00000453" || sLayoutName == "00000440" ||
+				sLayoutName == "0000080A" || sLayoutName == "0000046E" ||
+				sLayoutName == "0000044C" || sLayoutName == "0000043A" ||
+				sLayoutName == "0001043A" || sLayoutName == "00000481" ||
+				sLayoutName == "0000044E" || sLayoutName == "00000450" ||
+				sLayoutName == "00000850" || sLayoutName == "00000461" ||
+				sLayoutName == "00010415" || sLayoutName == "00000446" ||
+				sLayoutName == "00020418" || sLayoutName == "00010418" ||
+				sLayoutName == "00010419" || sLayoutName == "0000083B" ||
+				sLayoutName == "0000043B" || sLayoutName == "00000C1A" ||
+				sLayoutName == "0000081A" || sLayoutName == "0000046C" ||
+				sLayoutName == "00000432" || sLayoutName == "0000045B" ||
+				sLayoutName == "00000424" || sLayoutName == "0000082E" ||
+				sLayoutName == "0000042E" || sLayoutName == "0000045A" ||
+				sLayoutName == "00000428" || sLayoutName == "00000449" ||
+				sLayoutName == "00000444" || sLayoutName == "0000044A" ||
+				sLayoutName == "0000041E" || sLayoutName == "00000451" ||
+				sLayoutName == "0001041F" || sLayoutName == "00000442" ||
+				sLayoutName == "00000420" || sLayoutName == "00000480" ||
+				sLayoutName == "00000843" || sLayoutName == "00000452" ||
+				sLayoutName == "00000488" || sLayoutName == "0000046A")
 				return KeyboardLayout::QWERTY;
 
+			// Dvorak layouts
+			if (sLayoutName == "00010409" || sLayoutName == "00030409" || sLayoutName == "00040409")
+				return KeyboardLayout::DVORAK;
+
+			// Colemak layouts
+			if (sLayoutName == "00060409")
+				return KeyboardLayout::COLEMAK;
+
+			// AZERTY-based layouts
 			if (sLayoutName == "0000040C" || sLayoutName == "0000080C" ||
 				sLayoutName == "0000100C" || sLayoutName == "0000140C" ||
-				sLayoutName == "0000180C")
+				sLayoutName == "0000180C" || sLayoutName == "0001080C" ||
+				sLayoutName == "00000C0C" || sLayoutName == "00020401")
 				return KeyboardLayout::AZERTY;
 
+			// QWERTZ-based layouts
 			if (sLayoutName == "00000407" || sLayoutName == "00000807" ||
 				sLayoutName == "00000C07" || sLayoutName == "0000040E" ||
-				sLayoutName == "0000041B" || sLayoutName == "00000405")
+				sLayoutName == "0000041B" || sLayoutName == "00000405" ||
+				sLayoutName == "0000041A" || sLayoutName == "0000201A" ||
+				sLayoutName == "0000082C")
 				return KeyboardLayout::QWERTZ;
 		}
 		return KeyboardLayout::UNKNOWN;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### General

- Related issue: KeyBoard Layout didn't get detected
- Related functionality: DetectKeyboardLayout
- Feature in todo: Add more Keyboard Layout ( already did )
- Should be documented: no because it's a simple fix

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->
### Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Tests-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Description

Adding more sLayoutName in Misc.h. Also added COLEMAK and DVORAK compatibility

### Effect

People no longer say 'Fast stop doesn't work' because the main keyboard layouts will be added
