### PR TITLE
fix: Move EnemySound config from MiscCFG to ESPConfig

### DIFF
--- a/DragonBurn/Config/ConfigMenu.cpp
+++ b/DragonBurn/Config/ConfigMenu.cpp
@@ -215,8 +215,8 @@ namespace ConfigMenu {
 
 		MiscCFG::AutoAccept = false;
 
-        MiscCFG::EnemySound = false;
-        MiscCFG::EnemySoundColor = ImColor(255, 255, 255, 255);
+		ESPConfig::EnemySound = false;
+		ESPConfig::EnemySoundColor = ImColor(255, 255, 255, 255);
 
         MiscCFG::AutoKnife = false;
         MiscCFG::AutoKnifeDistance = 70.0f;

--- a/DragonBurn/Config/ConfigSaver.cpp
+++ b/DragonBurn/Config/ConfigSaver.cpp
@@ -107,6 +107,12 @@ namespace MyConfigSaver
         ConfigData["ESP"]["OutOfFOVColor"]["b"]=    ESPConfig::OutOfFOVArrowColor.Value.z;
         ConfigData["ESP"]["OutOfFOVColor"]["a"]=    ESPConfig::OutOfFOVArrowColor.Value.w;
 
+        ConfigData["ESP"]["EnemySound"] = ESPConfig::EnemySound;
+        ConfigData["ESP"]["EnemySoundColor"]["r"] = ESPConfig::EnemySoundColor.Value.x;
+        ConfigData["ESP"]["EnemySoundColor"]["g"] = ESPConfig::EnemySoundColor.Value.y;
+        ConfigData["ESP"]["EnemySoundColor"]["b"] = ESPConfig::EnemySoundColor.Value.z;
+        ConfigData["ESP"]["EnemySoundColor"]["a"] = ESPConfig::EnemySoundColor.Value.w;
+
 
         //ConfigData["Crosshairs"]["Enable"]=        CrosshairsCFG::ShowCrossHair;
         //ConfigData["Crosshairs"]["Size"]=          CrosshairsCFG::CrossHairSize;
@@ -215,7 +221,7 @@ namespace MyConfigSaver
         ConfigData["Misc"]["TimerColor"]["a"]=  MiscCFG::BombTimerCol.Value.w;
 
         ConfigData["Misc"]["Bhop"]=             MiscCFG::BunnyHop;
-        //ConfigData["Misc"]["FastStop"] =        MiscCFG::FastStop;
+        ConfigData["Misc"]["FastStop"] =        MiscCFG::FastStop;
         ConfigData["Misc"]["SpecList"]=         MiscCFG::SpecList;
 
         ConfigData["Misc"]["SniperCrosshair"] = MiscCFG::SniperCrosshair;
@@ -225,12 +231,6 @@ namespace MyConfigSaver
         ConfigData["Misc"]["SniperCrosshairColor"]["a"] = MiscCFG::SniperCrosshairColor.Value.w;
 
         ConfigData["Misc"]["AutoAccept"] = MiscCFG::AutoAccept;
-
-        ConfigData["Misc"]["EnemySound"] = MiscCFG::EnemySound;
-        ConfigData["Misc"]["EnemySoundColor"]["r"] = MiscCFG::EnemySoundColor.Value.x;
-        ConfigData["Misc"]["EnemySoundColor"]["g"] = MiscCFG::EnemySoundColor.Value.y;
-        ConfigData["Misc"]["EnemySoundColor"]["b"] = MiscCFG::EnemySoundColor.Value.z;
-        ConfigData["Misc"]["EnemySoundColor"]["a"] = MiscCFG::EnemySoundColor.Value.w;
 
         ConfigData["Misc"]["AutoKnife"] = MiscCFG::AutoKnife;
         ConfigData["Misc"]["AutoKnifeDistance"] = MiscCFG::AutoKnifeDistance;
@@ -353,6 +353,12 @@ namespace MyConfigSaver
             ESPConfig::EyeRayColor.Value.y = ReadData(ConfigData["ESP"], { "EyeRayColor","g" }, 0.f);
             ESPConfig::EyeRayColor.Value.z = ReadData(ConfigData["ESP"], { "EyeRayColor","b" }, 0.f);
             ESPConfig::EyeRayColor.Value.w = ReadData(ConfigData["ESP"], { "EyeRayColor","a" }, 255.f);
+
+            ESPConfig::EnemySound = ReadData(ConfigData["ESP"], { "EnemySound" }, false);
+            ESPConfig::EnemySoundColor.Value.x = ReadData(ConfigData["ESP"], { "EnemySoundColor","r" }, 0.f);
+            ESPConfig::EnemySoundColor.Value.y = ReadData(ConfigData["ESP"], { "EnemySoundColor","g" }, 0.f);
+            ESPConfig::EnemySoundColor.Value.z = ReadData(ConfigData["ESP"], { "EnemySoundColor","b" }, 0.f);
+            ESPConfig::EnemySoundColor.Value.w = ReadData(ConfigData["ESP"], { "EnemySoundColor","a" }, 255.f);
 
         }
 
@@ -478,13 +484,6 @@ namespace MyConfigSaver
             MiscCFG::SniperCrosshairColor.Value.w = ReadData(ConfigData["Misc"], { "SniperCrosshairColor","a" }, 255.f);
 
             MiscCFG::AutoAccept = ReadData(ConfigData["Misc"], { "AutoAccept" }, false);
-
-            MiscCFG::EnemySound = ReadData(ConfigData["Misc"], { "EnemySound" }, false);
-            MiscCFG::EnemySoundColor.Value.x = ReadData(ConfigData["Misc"], { "EnemySoundColor","r" }, 0.f);
-            MiscCFG::EnemySoundColor.Value.y = ReadData(ConfigData["Misc"], { "EnemySoundColor","g" }, 0.f);
-            MiscCFG::EnemySoundColor.Value.z = ReadData(ConfigData["Misc"], { "EnemySoundColor","b" }, 0.f);
-            MiscCFG::EnemySoundColor.Value.w = ReadData(ConfigData["Misc"], { "EnemySoundColor","a" }, 255.f);
-
             MiscCFG::AutoKnife = ReadData(ConfigData["Misc"], { "AutoKnife" }, false);
             MiscCFG::AutoKnifeDistance = ReadData(ConfigData["Misc"], { "AutoKnifeDistance" }, 70.0f);
             MiscCFG::AutoZeus = ReadData(ConfigData["Misc"], { "AutoZeus" }, false);

--- a/DragonBurn/Core/Cheats.cpp
+++ b/DragonBurn/Core/Cheats.cpp
@@ -220,7 +220,7 @@ std::vector<EntityResult> Cheats::ProcessEntities(CEntity& localEntity, int& loc
 			result.espRect = ESP::GetBoxRect(entity, ESPConfig::BoxType);
 
 		// sound esp
-		if (MiscCFG::EnemySound && result.entity.Controller.Address != localEntity.Controller.Address)
+		if (ESPConfig::ESPenabled && ESPConfig::EnemySound && result.entity.Controller.Address != localEntity.Controller.Address)
 			SoundESP::ProcessSound(result.entity, localEntity);
 
 		result.isValid = true;

--- a/DragonBurn/Core/Config.h
+++ b/DragonBurn/Core/Config.h
@@ -117,6 +117,9 @@ namespace ESPConfig
     inline bool ShowOutOfFOVArrow = false;
     inline float OutOfFOVRadiusFactor = 0.45f;
     inline ImColor OutOfFOVArrowColor = ImColor(255, 180, 50, 230);
+
+	inline bool EnemySound = false;
+	inline ImColor EnemySoundColor = ImColor(255, 255, 255, 255);
 }
 
 //namespace CrosshairsCFG
@@ -181,9 +184,6 @@ namespace MiscCFG
 	inline ImColor HeadShootLineColor = ImColor(131, 137, 150, 200);
 
     inline bool AutoAccept = false;
-
-    inline bool EnemySound = false;
-    inline ImColor EnemySoundColor = ImColor(255, 255, 255, 255);
 
     inline bool AutoKnife = false;
     inline float AutoKnifeDistance = 70.0f;

--- a/DragonBurn/Core/GUI.h
+++ b/DragonBurn/Core/GUI.h
@@ -358,7 +358,7 @@ namespace GUI
 						if(ESPConfig::ShowOutOfFOVArrow)
 							PutSliderFloat(Text::ESP::OutOfFOVRadius.c_str(), .5f, &ESPConfig::OutOfFOVRadiusFactor, &MinFovFactor, &MaxFovFactor, "%.1f");
 
-						PutSwitch(Text::ESP::SoundEsp.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::EnemySound, true, "###EnemySoundCol", reinterpret_cast<float*>(&MiscCFG::EnemySoundColor));
+						PutSwitch(Text::ESP::SoundEsp.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::EnemySound, true, "###EnemySoundCol", reinterpret_cast<float*>(&ESPConfig::EnemySoundColor));
 						PutSwitch(Text::ESP::HealthBar.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowHealthBar);
 						if (ESPConfig::ShowHealthBar)
 							PutSwitch(Text::ESP::HealthNum.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowHealthNum);

--- a/DragonBurn/Features/SoundESP.h
+++ b/DragonBurn/Features/SoundESP.h
@@ -116,7 +116,7 @@ namespace SoundESP {
             float startRadius = MaxRadius * 0.1f;
             float radius = startRadius + (MaxRadius - startRadius) * progress;
             
-            ImColor color = MiscCFG::EnemySoundColor;
+            ImColor color = ESPConfig::EnemySoundColor;
             color.Value.w *= (1.0f - progress);
 
             RenderSound(soundEffect.origin, radius, color);


### PR DESCRIPTION
Refactored EnemySound and EnemySoundColor settings to ESPConfig from MiscCFG for better organization. Updated all references in config saving/loading, GUI, and feature logic to use ESPConfig. This improves clarity and modularity for ESP-related features.

<!--- Provide a general summary of your changes in the title above -->

### General

- Related issue: -
- Related functionality: EnemySound, FastStop
- Feature in todo: - 
- Should be documented: n

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

### Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Regular code maintenance
- [ ] Tests-related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
