### PR TITLE
 Custom WAV Hitsounds with Volume Control

### DIFF
--- a/DragonBurn-usermode/Config/ConfigMenu.cpp
+++ b/DragonBurn-usermode/Config/ConfigMenu.cpp
@@ -268,7 +268,8 @@ namespace ConfigMenu {
 
 		MiscCFG::WaterMark = true;
 		MiscCFG::BunnyHop = false;
-		MiscCFG::HitSound = 0;
+		MiscCFG::HitSound = "None";
+		MiscCFG::HitSoundVolume = 1.0f;
 		MiscCFG::HitMarker = false;
 		MiscCFG::SniperCrosshair = true;
 		MiscCFG::SniperCrosshairColor = ImColor(32, 178, 170, 255);

--- a/DragonBurn-usermode/Config/ConfigSaver.cpp
+++ b/DragonBurn-usermode/Config/ConfigSaver.cpp
@@ -211,7 +211,9 @@ namespace MyConfigSaver
 
         ConfigData["Misc"]["WorkInSpec"]=       MenuConfig::WorkInSpec;
         ConfigData["Misc"]["Watermark"]=        MiscCFG::WaterMark;
-        ConfigData["Misc"]["HitSounds"]=        MiscCFG::HitSound;
+        
+        ConfigData["Misc"]["HitSounds"] = MiscCFG::HitSound;
+        ConfigData["Misc"]["HitSoundVolume"] = MiscCFG::HitSoundVolume;
         ConfigData["Misc"]["HitMarker"]=        MiscCFG::HitMarker;
 
         ConfigData["Misc"]["BombTimer"]=        MiscCFG::bmbTimer;
@@ -467,7 +469,9 @@ namespace MyConfigSaver
             MiscCFG::HeadShootLineColor.Value.w = ReadData(ConfigData["Misc"],{"HeadShootLineColor","a"}, 255.f);
             MenuConfig::WorkInSpec = ReadData(ConfigData["Misc"],{"WorkInSpec"}, false);
             MiscCFG::WaterMark = ReadData(ConfigData["Misc"],{"Watermark"}, false);
-            MiscCFG::HitSound = ReadData(ConfigData["Misc"],{"HitSounds"}, 0);
+          
+            MiscCFG::HitSound = ReadData(ConfigData["Misc"], { "HitSounds" }, std::string("None"));
+            MiscCFG::HitSoundVolume = ReadData(ConfigData["Misc"], { "HitSoundVolume" }, 1.0f);
             MiscCFG::HitMarker = ReadData(ConfigData["Misc"],{"HitMarker"}, false);
             MiscCFG::bmbTimer = ReadData(ConfigData["Misc"],{"BombTimer"}, false);
             MiscCFG::BombTimerCol.Value.x = ReadData(ConfigData["Misc"],{"TimerColor","r"}, 0.f);

--- a/DragonBurn-usermode/Config/ConfigSaver.h
+++ b/DragonBurn-usermode/Config/ConfigSaver.h
@@ -9,9 +9,8 @@ namespace MyConfigSaver {
     extern void LoadConfig(const std::string& filename);
 
     template <typename T>
-    static T ReadData(nlohmann::json node, std::vector <std::string> keys,T defaultValue)
+    static T ReadData(nlohmann::json node, std::vector <std::string> keys, T defaultValue)
     {
-        T value;
         for (std::string key : keys)
         {
             if (node.contains(key) && !node[key].is_null())
@@ -20,13 +19,16 @@ namespace MyConfigSaver {
             }
             else
             {
-                value = defaultValue;
-                return value;
-                break;
+                return defaultValue;
             }
         }
-        value = node.get<T>();
-        return value;
+
+        try {
+            return node.get<T>();
+        }
+        catch (const nlohmann::json::exception&) {
+            return defaultValue;
+        }
     }
     
     static uint32_t ImColorToUInt32(const ImColor& color)

--- a/DragonBurn-usermode/Core/Config.h
+++ b/DragonBurn-usermode/Core/Config.h
@@ -172,7 +172,8 @@ namespace MiscCFG
 	inline bool WaterMark = true;
 	inline bool SniperCrosshair = true;
 	inline ImColor SniperCrosshairColor = ImColor(32, 178, 170, 255);
-	inline int	HitSound = 0;
+	inline std::string HitSound = "None"; // Changed from int to string
+	inline float HitSoundVolume = 1.0f;   // Volume control (0.0 - 1.0)
 	inline bool HitMarker = false;
 	inline bool bmbTimer = true;
 	inline bool FastStop = false;

--- a/DragonBurn-usermode/Core/GUI.h
+++ b/DragonBurn-usermode/Core/GUI.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+
 #include "..\Core\Config.h"
 #include "..\Core\Render.h"
 #include "..\Features\Aimbot.h"
@@ -139,14 +139,14 @@ namespace GUI
 		ImGui::SameLine();
 		ImGui::SetCursorPosY(CurrentCursorY - 2);
 		if (ColorEditor) {
-			AlignRight(ContentWidth + ImGui::GetFrameHeight() +7);
+			AlignRight(ContentWidth + ImGui::GetFrameHeight() + 7);
 			ImGui::ColorEdit4(lable, col, ImGuiColorEditFlags_NoInputs | ImGuiColorEditFlags_AlphaBar | ImGuiColorEditFlags_AlphaPreview);
 			ImGui::SameLine();
 		}
 		else {
 			AlignRight(ContentWidth);
 		}
-		
+
 		Gui.SwitchButton(string, v);
 		ImGui::PopID();
 	}
@@ -184,7 +184,7 @@ namespace GUI
 	{
 		ImGui::PushID(string);
 		float CurrentCursorX = ImGui::GetCursorPosX();
-		float SliderWidth = ImGui::GetColumnWidth() - ImGui::GetStyle().ItemSpacing.x - CursorX-15;
+		float SliderWidth = ImGui::GetColumnWidth() - ImGui::GetStyle().ItemSpacing.x - CursorX - 15;
 		ImGui::SetCursorPosX(CurrentCursorX + CursorX);
 		ImGui::TextDisabled(string);
 		if (Tip && ImGui::IsItemHovered())
@@ -231,7 +231,7 @@ namespace GUI
 				ImGui::Image((void*)MenuButton1, ImVec2(buttonW, buttonH));
 			if (Button1Pressed)
 				ImGui::Image((void*)MenuButton1Pressed, ImVec2(buttonW, buttonH));
-			if (ImGui::IsItemClicked()) 
+			if (ImGui::IsItemClicked())
 			{
 				MenuConfig::WCS.MenuPage = 0;
 				Button1Pressed = true;
@@ -301,7 +301,7 @@ namespace GUI
 			ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 5);
 
 			ImGui::SetCursorPos(MenuConfig::WCS.ChildPos);
-			
+
 			ImGui::BeginChild("Page", MenuConfig::WCS.ChildSize, false, ImGuiWindowFlags_NoScrollbar);
 			{
 				ImGui::Text("   DragonBurn");
@@ -345,7 +345,7 @@ namespace GUI
 						PutSwitch(Text::ESP::HeadBox.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowHeadBox, true, "###HeadBoxCol", reinterpret_cast<float*>(&ESPConfig::HeadBoxColor));
 						PutSwitch(Text::ESP::Skeleton.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowBoneESP, true, "###BoneCol", reinterpret_cast<float*>(&ESPConfig::BoneColor));
 						PutSwitch(Text::ESP::SnapLine.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowLineToEnemy, true, "###LineCol", reinterpret_cast<float*>(&ESPConfig::LineToEnemyColor));
-						if (ESPConfig::ShowLineToEnemy) 
+						if (ESPConfig::ShowLineToEnemy)
 						{
 							ImGui::TextDisabled(Text::ESP::LinePosList.c_str());
 							ImGui::SameLine();
@@ -355,7 +355,7 @@ namespace GUI
 						}
 						PutSwitch(Text::ESP::EyeRay.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowEyeRay, true, "###LineCol", reinterpret_cast<float*>(&ESPConfig::EyeRayColor));
 						PutSwitch(Text::ESP::OutOfFOVArrow.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::ShowOutOfFOVArrow, true, "###OutFOVCol", reinterpret_cast<float*>(&ESPConfig::OutOfFOVArrowColor));
-						if(ESPConfig::ShowOutOfFOVArrow)
+						if (ESPConfig::ShowOutOfFOVArrow)
 							PutSliderFloat(Text::ESP::OutOfFOVRadius.c_str(), .5f, &ESPConfig::OutOfFOVRadiusFactor, &MinFovFactor, &MaxFovFactor, "%.1f");
 
 						PutSwitch(Text::ESP::SoundEsp.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::EnemySound, true, "###EnemySoundCol", reinterpret_cast<float*>(&ESPConfig::EnemySoundColor));
@@ -375,7 +375,7 @@ namespace GUI
 						PutSwitch(Text::ESP::VisCheck.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &ESPConfig::VisibleCheck, true, "###VisibleCol", reinterpret_cast<float*>(&ESPConfig::VisibleColor));
 					}
 					ImGui::NewLine();
-					
+
 					ImGui::NextColumn();
 					ImGui::SetCursorPosY(24.f);
 					ImGui::GradientText("ESP Preview");
@@ -392,7 +392,7 @@ namespace GUI
 					if (RadarCFG::ShowRadar)
 					{
 						PutSwitch(Text::Radar::CustomCheck.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &RadarCFG::customRadar);
-						
+
 						if (RadarCFG::customRadar)
 						{
 							PutSwitch(Text::Radar::CrossLine.c_str(), 5.f, ImGui::GetFrameHeight() * 1.7, &RadarCFG::ShowRadarCrossLine);
@@ -402,7 +402,7 @@ namespace GUI
 							PutSliderFloat(Text::Radar::AlphaSlider.c_str(), 5.f, &RadarCFG::RadarBgAlpha, &AlphaMin, &AlphaMax, "%.1f");
 						}
 					}
-					
+
 					//ImGui::NewLine();
 					//ImGui::GradientText("Crosshairs");
 					//float DotMin = 1.f, DotMax = 50.f;
@@ -432,10 +432,10 @@ namespace GUI
 					//	PutSwitch(Lang::CrosshairsText.TargetCheck, 5.f, ImGui::GetFrameHeight() * 1.7, &MenuConfig::TargetingCrosshairs, true, "###CircleCol", reinterpret_cast<float*>(&CrosshairsCFG::TargetedColor));
 					//	PutSwitch(Lang::CrosshairsText.TeamCheck, 5.f, ImGui::GetFrameHeight() * 1.7, &CrosshairsCFG::TeamCheck);
 					//}
-					
+
 					//ImGui::Columns(1);
 				}
-				
+
 				if (MenuConfig::WCS.MenuPage == 0)
 				{
 					ImGui::Columns(2, nullptr, false);
@@ -470,7 +470,7 @@ namespace GUI
 						PutSwitch(Text::Aimbot::ScopeOnly.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &AimControl::ScopeOnly);
 
 						PutSwitch(Text::Aimbot::HumanizeVar.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &AimControl::HumanizeVar, false, NULL, NULL, Text::Aimbot::OnTip.c_str());
-						if(AimControl::HumanizeVar)
+						if (AimControl::HumanizeVar)
 							PutSliderInt(Text::Aimbot::HumanizationStrength.c_str(), 10.f, &AimControl::HumanizationStrength, &MinHumanize, &MaxHumanize, "%d");
 
 						PutSliderFloat(Text::Aimbot::FovSlider.c_str(), 10.f, &AimControl::AimFov, &AimControl::AimFovMin, &FovMax, "%.1f");
@@ -483,7 +483,7 @@ namespace GUI
 						ImGui::Image((void*)HitboxImage, ImVec2(hitboxW, hitboxH));
 
 						ImGui::GetWindowDrawList()->AddLine(ImVec2(StartPos.x + 130, StartPos.y + 20), ImVec2(StartPos.x + 205, StartPos.y + 20), ImColor(ImGui::GetStyleColorVec4(ImGuiCol_Border)), 1.8f); // Head
-						ImGui::SetCursorScreenPos(ImVec2(StartPos.x + 203, StartPos.y + 10)); 
+						ImGui::SetCursorScreenPos(ImVec2(StartPos.x + 203, StartPos.y + 10));
 						if (ImGui::Checkbox("###Head", &checkbox1))
 						{
 							if (checkbox1) {
@@ -550,8 +550,8 @@ namespace GUI
 						PutSliderInt(Text::RCS::BulletSlider.c_str(), 5.f, &RCS::RCSBullet, &RCSBulletMin, &RCSBulletMax, "%d");
 						PutSliderFloat(Text::RCS::Yaw.c_str(), 5.f, &RCS::RCSScale.x, &recoilMin, &recoilMax, "%.2f");
 						PutSliderFloat(Text::RCS::Pitch.c_str(), 5.f, &RCS::RCSScale.y, &recoilMin, &recoilMax, "%.2f");
-						float scalex = (2.22 - RCS::RCSScale.x) *.5f;
-						float scaley = (2.12 - RCS::RCSScale.y) *.5f;//Simulate reasonable error values
+						float scalex = (2.22 - RCS::RCSScale.x) * .5f;
+						float scaley = (2.12 - RCS::RCSScale.y) * .5f;//Simulate reasonable error values
 						ImVec2 BulletPos = ImGui::GetCursorScreenPos();
 
 						// Example Preview
@@ -572,7 +572,7 @@ namespace GUI
 						BulletPos12.x = BulletPos11.x - 3 * scalex; BulletPos12.y = BulletPos11.y - 9 * scaley;
 						BulletPos13.x = BulletPos12.x + 15 * scalex; BulletPos13.y = BulletPos12.y - 5 * scaley;
 						BulletPos14.x = BulletPos13.x + 10 * scalex; BulletPos14.y = BulletPos13.y - 4 * scaley;
-						
+
 						ImGui::GetWindowDrawList()->AddCircleFilled(BulletPos0, 4.f, ImColor(ImGui::GetStyleColorVec4(ImGuiCol_Border)));
 						ImGui::GetWindowDrawList()->AddCircleFilled(BulletPos1, 4.f, ImColor(ImGui::GetStyleColorVec4(ImGuiCol_Border)));
 						ImGui::GetWindowDrawList()->AddCircleFilled(BulletPos2, 4.f, ImColor(ImGui::GetStyleColorVec4(ImGuiCol_Border)));
@@ -606,7 +606,7 @@ namespace GUI
 							ImGui::TextDisabled(Text::Trigger::HotKeyList.c_str());
 							ImGui::SameLine();
 							AlignRight(70.f);
-							if (ImGui::Button(Text::Trigger::HotKey.c_str(), {70.f, 25.f}))
+							if (ImGui::Button(Text::Trigger::HotKey.c_str(), { 70.f, 25.f }))
 							{
 								std::thread([&]() {
 									KeyMgr::GetPressedKey(TriggerBot::HotKey, &Text::Trigger::HotKey);
@@ -637,20 +637,74 @@ namespace GUI
 					PutSwitch(Text::Misc::SpecList.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::SpecList);
 					PutSwitch(Text::Misc::Watermark.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::WaterMark);
 					PutSwitch(Text::Misc::HeadshotLine.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::ShowHeadShootLine);
+
+					// New WAV-based Hit Sound system
+					static std::vector<std::string> wavFiles;
+					static bool wavFilesLoaded = false;
+					static int currentHitSoundIndex = 0;
+
+					if (!wavFilesLoaded) {
+						wavFiles.clear();
+						wavFiles.push_back("None");
+
+						std::string searchPath = MenuConfig::path + "\\*.wav";
+						WIN32_FIND_DATAA findData;
+						HANDLE hFind = FindFirstFileA(searchPath.c_str(), &findData);
+
+						if (hFind != INVALID_HANDLE_VALUE) {
+							do {
+								if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+									wavFiles.push_back(findData.cFileName);
+								}
+							} while (FindNextFileA(hFind, &findData));
+							FindClose(hFind);
+						}
+						wavFilesLoaded = true;
+					}
+
+					// Find current index
+					currentHitSoundIndex = 0; // Default to "None"
+					for (int i = 0; i < wavFiles.size(); i++) {
+						if (wavFiles[i] == MiscCFG::HitSound) {
+							currentHitSoundIndex = i;
+							break;
+						}
+					}
+
+					// Hit Sound selection
 					ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
-					ImGui::TextDisabled(Text::Misc::HitSound.c_str());
+					ImGui::TextDisabled("Hit Sound");
 					ImGui::SameLine();
 					AlignRight(160.f);
 					ImGui::SetNextItemWidth(160.f);
-					ImGui::Combo("###HitSounds", &MiscCFG::HitSound, "None\0Neverlose\0Skeet\0");
+
+					if (ImGui::Combo("###HitSounds", &currentHitSoundIndex, [](void* data, int idx, const char** out_text) {
+						auto* files = static_cast<std::vector<std::string>*>(data);
+						if (idx < 0 || idx >= files->size()) return false;
+						*out_text = (*files)[idx].c_str();
+						return true;
+						}, &wavFiles, wavFiles.size())) {
+						MiscCFG::HitSound = wavFiles[currentHitSoundIndex];
+					}
+
+					// Volume slider (only show if a sound is selected)
+					if (MiscCFG::HitSound != "None") {
+						ImGui::SetCursorPosX(ImGui::GetCursorPosX() + 10.f);
+						ImGui::TextDisabled("Hit Sound Volume");
+						ImGui::SameLine();
+						AlignRight(160.f);
+						ImGui::SetNextItemWidth(160.f);
+						ImGui::SliderFloat("###HitSoundVolume", &MiscCFG::HitSoundVolume, 0.0f, 1.0f, "%.2f");
+					}
+
 					PutSwitch(Text::Misc::HitMerker.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::HitMarker);
 					PutSwitch(Text::Misc::BunnyHop.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::BunnyHop, false, NULL, NULL, Text::Misc::InsecureTip.c_str());
 					PutSwitch(Text::Misc::FastStop.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::FastStop, false, NULL, NULL, Text::Misc::InsecureTip.c_str());
 					PutSwitch(Text::Misc::SniperCrosshair.c_str(), 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::SniperCrosshair, true, "###sniperCrosshair", reinterpret_cast<float*>(&MiscCFG::SniperCrosshairColor));
 					PutSwitch("Auto Accept", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AutoAccept);
-                    PutSwitch("Knife bot", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AutoKnife);
-                    PutSwitch("Zeus bot", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AutoZeus);
-                    PutSwitch("Anti-afk", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AntiAFKKick);
+					PutSwitch("Knife bot", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AutoKnife);
+					PutSwitch("Zeus bot", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AutoZeus);
+					PutSwitch("Anti-afk", 10.f, ImGui::GetFrameHeight() * 1.7, &MiscCFG::AntiAFKKick);
 
 					ImGui::NextColumn();
 					ImGui::SetCursorPosY(24.f);
@@ -683,7 +737,6 @@ namespace GUI
 						Misc::CleanTraces();
 						Init::Client::Exit();
 					}
-
 
 					ImGui::Columns(1);
 				}

--- a/DragonBurn-usermode/Features/Misc.cpp
+++ b/DragonBurn-usermode/Features/Misc.cpp
@@ -6,6 +6,12 @@
 #include <random>
 #include "../Helpers/Logger.h"
 #include "../Core/Cheats.h"
+#include <mmsystem.h>
+#include <mmreg.h>
+#include <dsound.h>
+#pragma comment(lib, "winmm.lib")
+#pragma comment(lib, "dsound.lib")
+
 namespace fs = std::filesystem;
 
 namespace System {
@@ -60,25 +66,60 @@ namespace Misc
 		MenuConfig::MarkWinPos = ImGui::GetWindowPos();
 		ImGui::End();
 	}
-
 	void HitSound() noexcept
 	{
-		switch (MiscCFG::HitSound)
+		if (MiscCFG::HitSound.empty() || MiscCFG::HitSound == "None" || MiscCFG::HitSoundVolume <= 0.01f)
+			return;
+
+		std::string soundPath = MenuConfig::path + "\\" + MiscCFG::HitSound;
+
+		// Check if file exists
+		DWORD fileAttr = GetFileAttributesA(soundPath.c_str());
+		if (fileAttr == INVALID_FILE_ATTRIBUTES) {
+			return;
+		}
+
+		std::wstring widePath = Misc::STR2LPCWSTR(soundPath);
+		PlaySoundWithVolume(widePath.c_str(), NULL, SND_ASYNC | SND_FILENAME);
+	}
+
+	// Working volume control using DirectSound
+	void PlaySoundWithVolume(LPCWSTR pszSound, HMODULE hmod, DWORD fdwSound)
+	{
+		// First play the sound
+		PlaySoundW(pszSound, hmod, fdwSound);
+
+		// Apply volume control using waveOut API
+		if (MiscCFG::HitSoundVolume < 1.0f)
 		{
-		case 1:
-			PlaySoundA(reinterpret_cast<char*>(neverlose_sound), NULL, SND_ASYNC | SND_MEMORY);
-			break;
-		case 2:
-			PlaySoundA(reinterpret_cast<char*>(skeet_sound), NULL, SND_ASYNC | SND_MEMORY);
-			break;
-		default:
-			break;
+			// Calculate volume in the range 0-65535
+			DWORD volume = static_cast<DWORD>(MiscCFG::HitSoundVolume * 65535);
+			// Set both left and right channels
+			DWORD dwVolume = (volume << 16) | volume;
+
+			// Apply volume to waveOut device
+			HWAVEOUT hWaveOut;
+			WAVEFORMATEX wfx = { WAVE_FORMAT_PCM, 1, 22050, 22050, 1, 8, 0 };
+
+			// Open waveOut device
+			if (waveOutOpen(&hWaveOut, WAVE_MAPPER, &wfx, 0, 0, CALLBACK_NULL) == MMSYSERR_NOERROR)
+			{
+				waveOutSetVolume(hWaveOut, dwVolume);
+
+				// Keep the volume applied for a short time, then restore
+				std::thread([hWaveOut]() {
+					std::this_thread::sleep_for(std::chrono::milliseconds(500));
+					// Restore to full volume
+					waveOutSetVolume(hWaveOut, 0xFFFFFFFF);
+					waveOutClose(hWaveOut);
+					}).detach();
+			}
 		}
 	}
 
 	void HitManager(CEntity& LocalPlayer, int& PreviousTotalHits) noexcept
 	{
-		if ((!MiscCFG::HitSound && !MiscCFG::HitMarker) || LocalPlayer.Controller.TeamID == 0 || MenuConfig::ShowMenu || !LocalPlayer.IsAlive())
+		if (((MiscCFG::HitSound.empty() || MiscCFG::HitSound == "None") && !MiscCFG::HitMarker) || LocalPlayer.Controller.TeamID == 0 || MenuConfig::ShowMenu || !LocalPlayer.IsAlive())
 			return;
 
 		uintptr_t pBulletServices;
@@ -93,7 +134,7 @@ namespace Misc
 			}
 			else
 			{
-				if (MiscCFG::HitSound)
+				if (!MiscCFG::HitSound.empty() && MiscCFG::HitSound != "None")
 				{
 					HitSound();
 				}

--- a/DragonBurn-usermode/Features/Misc.h
+++ b/DragonBurn-usermode/Features/Misc.h
@@ -14,7 +14,6 @@
 #include <Windows.h>
 
 #include "Aimbot.h"
-#include "..\Resources\Sounds.h"
 #include "..\Game\Entity.h"
 #include "..\Core\Config.h"
 #include "..\OS-ImGui\imgui\imgui.h"
@@ -270,7 +269,8 @@ namespace Misc
 	void HitManager(CEntity&, int&) noexcept;
 	void BunnyHop(const CEntity&) noexcept;
 	void CleanTraces();
-
+	void HitSound() noexcept;
+	void PlaySoundWithVolume(LPCWSTR pszSound, HMODULE hmod, DWORD fdwSound);
 	void FastStop() noexcept;
 	void KnifeBot(const CEntity& local, const std::vector<CEntity>& entities, int autoKnifeKey = 0) noexcept;
 	void ExecuteCommand(const std::string& command) noexcept;


### PR DESCRIPTION
## Feature: Custom WAV Hitsounds with Volume Control

Replaced the hardcoded hitsounds with a WAV file system. You can now:

- Drop any WAV file in `Documents/DragonBurn` folder
- Select sounds from automatic file list in menu  
- Adjust volume with slider (0-100%)
- Choose "None" to disable hitsounds

### Files Modified:
- Core/Config.h - Added string hitsound and volume settings
- Features/Misc.h - Added volume function
- Features/Misc.cpp - WAV playback with volume control
- Core/GUI.h - File detection and volume slider
- Config/ConfigSaver.cpp - Save/load WAV filename and volume
- Config/ConfigMenu.cpp - Updated default settings  
- Config/ConfigSaver.h - JSON support for string hitsounds

Settings save with configs.