### PR TITLE
fix: skip rendering when window is not focused

### DIFF
--- a/DragonBurn-usermode/OS-ImGui/OS-ImGui_External.cpp
+++ b/DragonBurn-usermode/OS-ImGui/OS-ImGui_External.cpp
@@ -294,6 +294,24 @@ namespace OSImGui
             if (Type == ATTACH && !UpdateWindowData()) 
                 break;
 
+            // Skip rendering when the game window is not focused
+            if (Type == ATTACH) {
+                HWND hForeground = GetForegroundWindow();
+
+                if (hForeground != DestWindow.hWnd && hForeground != Window.hWnd) {
+                    const float* actualClearColor = reinterpret_cast<const float*>(&Window.BgColor.Value);
+
+                    g_Device.g_pd3dDeviceContext->OMSetRenderTargets(1, &g_Device.g_mainRenderTargetView, nullptr);
+                    g_Device.g_pd3dDeviceContext->ClearRenderTargetView(g_Device.g_mainRenderTargetView, actualClearColor);
+
+                    g_Device.g_pSwapChain->Present(0, 0);
+                    frameSkip = 0;
+
+                    Sleep(1);
+                    continue;
+                }
+            }
+
             ImGuiIO& io = ImGui::GetIO();
 
             static bool keyState[256] = { true }; // Track keys


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### General

- Related functionality: Rendering
- Should be documented: n

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

### Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Regular code maintenance
- [ ] Tests-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Description

Fixed an issue where visuals were still rendering when the game wasn't focused/alt-tabbed, specifically while the menu was open.