### PR TITLE
refactor: update offset provider to a2x/cs2-dumper and improve update…

### DIFF
--- a/DragonBurn-usermode/Helpers/StorageMgr.cpp
+++ b/DragonBurn-usermode/Helpers/StorageMgr.cpp
@@ -37,3 +37,9 @@ void storage::WriteStorageFile(const std::string& path, const std::string& data)
     else
         throw std::runtime_error("Failed to open local storage");
 }
+
+bool storage::FileExists(const std::string& path)
+{
+    std::string localStorageFile = MenuConfig::path + "\\Data\\" + path;
+    return std::filesystem::exists(localStorageFile);
+}

--- a/DragonBurn-usermode/Helpers/StorageMgr.h
+++ b/DragonBurn-usermode/Helpers/StorageMgr.h
@@ -10,5 +10,6 @@ namespace storage
 {
 	std::string ReadStorageFile(const std::string& path);
 	void WriteStorageFile(const std::string& path, const std::string& data);
+	bool FileExists(const std::string& path);
 }
 

--- a/DragonBurn-usermode/Offsets/Offsets.cpp
+++ b/DragonBurn-usermode/Offsets/Offsets.cpp
@@ -8,135 +8,170 @@ Offsets::~Offsets() {}
 
 void Offsets::SetOffsets(const std::string& offsetsData, const std::string& buttonsData, const std::string& client_dllData)
 {
-    json offsetsJson = json::parse(offsetsData);
-    json buttonsJson = json::parse(buttonsData);
-    json client_dllJson = json::parse(client_dllData)["client.dll"]["classes"];
+    try {
+        json offsetsJson = json::parse(offsetsData);
+        json buttonsJson = json::parse(buttonsData);
+        json client_dllJson = json::parse(client_dllData)["client.dll"]["classes"];
 
-    this->EntityList = offsetsJson["client.dll"]["dwEntityList"];
-    this->Matrix = offsetsJson["client.dll"]["dwViewMatrix"];
-    this->ViewAngle = offsetsJson["client.dll"]["dwViewAngles"];
-    this->LocalPlayerController = offsetsJson["client.dll"]["dwLocalPlayerController"];
-    this->LocalPlayerPawn = offsetsJson["client.dll"]["dwLocalPlayerPawn"];
-    this->GlobalVars = offsetsJson["client.dll"]["dwGlobalVars"];
-    this->PlantedC4 = offsetsJson["client.dll"]["dwPlantedC4"];
-    this->InputSystem = offsetsJson["inputsystem.dll"]["dwInputSystem"];
-    this->Sensitivity = offsetsJson["client.dll"]["dwSensitivity"];
-    this->Sensitivity_sensitivity = offsetsJson["client.dll"]["dwSensitivity_sensitivity"];
+        auto get_offset = [&](json& j, const std::string& key) -> DWORD {
+            if (j.contains(key) && !j[key].is_null())
+                return j[key].get<DWORD>();
+            return 0;
+        };
 
-    this->Buttons.Attack = buttonsJson["client.dll"]["attack"];
-    this->Buttons.Jump = buttonsJson["client.dll"]["jump"];
-    this->Buttons.Right = buttonsJson["client.dll"]["right"];
-    this->Buttons.Left = buttonsJson["client.dll"]["left"];
+        auto get_class_field = [&](const std::string& className, const std::string& fieldName) -> DWORD {
+            if (client_dllJson.contains(className) && 
+                client_dllJson[className].contains("fields") && 
+                client_dllJson[className]["fields"].contains(fieldName)) {
+                return client_dllJson[className]["fields"][fieldName].get<DWORD>();
+            }
+            return 0;
+        };
 
-    this->Entity.IsAlive = client_dllJson["CCSPlayerController"]["fields"]["m_bPawnIsAlive"];
-    this->Entity.PlayerPawn = client_dllJson["CCSPlayerController"]["fields"]["m_hPlayerPawn"];
-    this->Entity.iszPlayerName = client_dllJson["CBasePlayerController"]["fields"]["m_iszPlayerName"];
+        this->EntityList = offsetsJson["client.dll"]["dwEntityList"];
+        this->Matrix = offsetsJson["client.dll"]["dwViewMatrix"];
+        this->ViewAngle = offsetsJson["client.dll"]["dwViewAngles"];
+        this->LocalPlayerController = offsetsJson["client.dll"]["dwLocalPlayerController"];
+        this->LocalPlayerPawn = offsetsJson["client.dll"]["dwLocalPlayerPawn"];
+        this->GlobalVars = offsetsJson["client.dll"]["dwGlobalVars"];
+        this->PlantedC4 = offsetsJson["client.dll"]["dwPlantedC4"];
+        this->InputSystem = offsetsJson["inputsystem.dll"]["dwInputSystem"];
+        this->Sensitivity = offsetsJson["client.dll"]["dwSensitivity"];
+        this->Sensitivity_sensitivity = offsetsJson["client.dll"]["dwSensitivity_sensitivity"];
 
-    this->Pawn.BulletServices = client_dllJson["C_CSPlayerPawn"]["fields"]["m_pBulletServices"];
-    this->Pawn.CameraServices = client_dllJson["C_BasePlayerPawn"]["fields"]["m_pCameraServices"];
-    this->Pawn.pClippingWeapon = client_dllJson["C_CSPlayerPawn"]["fields"]["m_pClippingWeapon"];
-    this->Pawn.isScoped = client_dllJson["C_CSPlayerPawn"]["fields"]["m_bIsScoped"];
-    this->Pawn.isDefusing = client_dllJson["C_CSPlayerPawn"]["fields"]["m_bIsDefusing"];
-    this->Pawn.TotalHit = client_dllJson["CCSPlayer_BulletServices"]["fields"]["m_totalHitsOnServer"];
-    this->Pawn.Pos = client_dllJson["C_BasePlayerPawn"]["fields"]["m_vOldOrigin"];
-    this->Pawn.CurrentArmor = client_dllJson["C_CSPlayerPawn"]["fields"]["m_ArmorValue"];
-    this->Pawn.MaxHealth = client_dllJson["C_BaseEntity"]["fields"]["m_iMaxHealth"];
-    this->Pawn.CurrentHealth = client_dllJson["C_BaseEntity"]["fields"]["m_iHealth"];
-    this->Pawn.GameSceneNode = client_dllJson["C_BaseEntity"]["fields"]["m_pGameSceneNode"];
-    this->Pawn.BoneArray = client_dllJson["CSkeletonInstance"]["fields"]["m_modelState"] + 0x80;
-    this->Pawn.angEyeAngles = client_dllJson["C_CSPlayerPawn"]["fields"]["m_angEyeAngles"];
-    this->Pawn.vecLastClipCameraPos = client_dllJson["C_CSPlayerPawn"]["fields"]["m_vecLastClipCameraPos"];
-    this->Pawn.iShotsFired = client_dllJson["C_CSPlayerPawn"]["fields"]["m_iShotsFired"];
-    this->Pawn.flFlashDuration = client_dllJson["C_CSPlayerPawnBase"]["fields"]["m_flFlashDuration"];
-    this->Pawn.aimPunchAngle = client_dllJson["C_CSPlayerPawn"]["fields"]["m_aimPunchAngle"];
-    this->Pawn.aimPunchCache = client_dllJson["C_CSPlayerPawn"]["fields"]["m_aimPunchCache"];
-    this->Pawn.iIDEntIndex = client_dllJson["C_CSPlayerPawn"]["fields"]["m_iIDEntIndex"];
-    this->Pawn.iTeamNum = client_dllJson["C_BaseEntity"]["fields"]["m_iTeamNum"];
-    this->Pawn.iFovStart = client_dllJson["CCSPlayerBase_CameraServices"]["fields"]["m_iFOVStart"];
-    this->Pawn.fFlags = client_dllJson["C_BaseEntity"]["fields"]["m_fFlags"];
-    this->Pawn.bSpottedByMask = DWORD(client_dllJson["C_CSPlayerPawn"]["fields"]["m_entitySpottedState"]) + DWORD(client_dllJson["EntitySpottedState_t"]["fields"]["m_bSpottedByMask"]);
-    this->Pawn.AbsVelocity = client_dllJson["C_BaseEntity"]["fields"]["m_vecAbsVelocity"];
-    this->Pawn.m_bWaitForNoAttack = client_dllJson["C_CSPlayerPawn"]["fields"]["m_bWaitForNoAttack"];
-    this->Pawn.m_pWeaponServices = client_dllJson["C_BasePlayerPawn"]["fields"]["m_pWeaponServices"];
-    this->Pawn.m_flEmitSoundTime = client_dllJson["C_CSPlayerPawn"]["fields"]["m_flEmitSoundTime"];
+        this->Buttons.Attack = buttonsJson["client.dll"]["attack"];
+        this->Buttons.Jump = buttonsJson["client.dll"]["jump"];
+        this->Buttons.Right = buttonsJson["client.dll"]["right"];
+        this->Buttons.Left = buttonsJson["client.dll"]["left"];
 
-    this->GlobalVar.RealTime = 0x00;
-    this->GlobalVar.FrameCount = 0x04;
-    this->GlobalVar.MaxClients = 0x10;
-    this->GlobalVar.IntervalPerTick = 0x14;
-    this->GlobalVar.CurrentTime = 0x30;
-    this->GlobalVar.CurrentTime2 = 0x38;
-    this->GlobalVar.TickCount = 0x48;
-    this->GlobalVar.IntervalPerTick2 = 0x44;
-    this->GlobalVar.CurrentNetchan = 0x0048;
-    this->GlobalVar.CurrentMap = 0x0180;
-    this->GlobalVar.CurrentMapName = 0x0188;
+        this->Entity.IsAlive = get_class_field("CCSPlayerController", "m_bPawnIsAlive");
+        this->Entity.PlayerPawn = get_class_field("CCSPlayerController", "m_hPlayerPawn");
+        this->Entity.iszPlayerName = get_class_field("CBasePlayerController", "m_iszPlayerName");
 
-    this->PlayerController.m_nTickBase = client_dllJson["CBasePlayerController"]["fields"]["m_nTickBase"];
-    this->PlayerController.m_steamID = client_dllJson["CBasePlayerController"]["fields"]["m_steamID"];
-    this->PlayerController.m_hPawn = client_dllJson["CBasePlayerController"]["fields"]["m_hPawn"];
-    this->PlayerController.m_pObserverServices = client_dllJson["C_BasePlayerPawn"]["fields"]["m_pObserverServices"];
-    this->PlayerController.m_hObserverTarget = client_dllJson["CPlayer_ObserverServices"]["fields"]["m_hObserverTarget"];
-    this->PlayerController.m_hController = client_dllJson["C_BasePlayerPawn"]["fields"]["m_hController"];
-    this->PlayerController.PawnArmor = client_dllJson["CCSPlayerController"]["fields"]["m_iPawnArmor"];
-    this->PlayerController.HasDefuser = client_dllJson["CCSPlayerController"]["fields"]["m_bPawnHasDefuser"];
-    this->PlayerController.HasHelmet = client_dllJson["CCSPlayerController"]["fields"]["m_bPawnHasHelmet"];
+        this->Pawn.BulletServices = get_class_field("C_CSPlayerPawn", "m_pBulletServices");
+        this->Pawn.CameraServices = get_class_field("C_BasePlayerPawn", "m_pCameraServices");
+        this->Pawn.pClippingWeapon = get_class_field("C_CSPlayerPawn", "m_pClippingWeapon");
+        this->Pawn.isScoped = get_class_field("C_CSPlayerPawn", "m_bIsScoped");
+        this->Pawn.isDefusing = get_class_field("C_CSPlayerPawn", "m_bIsDefusing");
+        this->Pawn.TotalHit = get_class_field("CCSPlayer_BulletServices", "m_totalHitsOnServer");
+        this->Pawn.Pos = get_class_field("C_BasePlayerPawn", "m_vOldOrigin");
+        this->Pawn.CurrentArmor = get_class_field("C_CSPlayerPawn", "m_ArmorValue");
+        this->Pawn.MaxHealth = get_class_field("C_BaseEntity", "m_iMaxHealth");
+        this->Pawn.CurrentHealth = get_class_field("C_BaseEntity", "m_iHealth");
+        this->Pawn.GameSceneNode = get_class_field("C_BaseEntity", "m_pGameSceneNode");
+        this->Pawn.BoneArray = get_class_field("CSkeletonInstance", "m_modelState") + 0x80;
+        this->Pawn.angEyeAngles = get_class_field("C_CSPlayerPawn", "m_angEyeAngles");
+        this->Pawn.vecLastClipCameraPos = get_class_field("C_CSPlayerPawn", "m_vecLastClipCameraPos");
+        this->Pawn.iShotsFired = get_class_field("C_CSPlayerPawn", "m_iShotsFired");
+        this->Pawn.flFlashDuration = get_class_field("C_CSPlayerPawnBase", "m_flFlashDuration");
+        this->Pawn.aimPunchAngle = get_class_field("C_CSPlayerPawn", "m_aimPunchAngle");
+        this->Pawn.aimPunchCache = get_class_field("C_CSPlayerPawn", "m_aimPunchCache");
+        this->Pawn.iIDEntIndex = get_class_field("C_CSPlayerPawn", "m_iIDEntIndex");
+        this->Pawn.iTeamNum = get_class_field("C_BaseEntity", "m_iTeamNum");
+        this->Pawn.iFovStart = get_class_field("CCSPlayerBase_CameraServices", "m_iFOVStart");
+        this->Pawn.fFlags = get_class_field("C_BaseEntity", "m_fFlags");
+        this->Pawn.bSpottedByMask = get_class_field("C_CSPlayerPawn", "m_entitySpottedState") + get_class_field("EntitySpottedState_t", "m_bSpottedByMask");
+        this->Pawn.AbsVelocity = get_class_field("C_BaseEntity", "m_vecAbsVelocity");
+        this->Pawn.m_bWaitForNoAttack = get_class_field("C_CSPlayerPawn", "m_bWaitForNoAttack");
+        this->Pawn.m_pWeaponServices = get_class_field("C_BasePlayerPawn", "m_pWeaponServices");
+        this->Pawn.m_flEmitSoundTime = get_class_field("C_CSPlayerPawn", "m_flEmitSoundTime");
 
-    this->EconEntity.AttributeManager = client_dllJson["C_EconEntity"]["fields"]["m_AttributeManager"];
+        this->GlobalVar.RealTime = 0x00;
+        this->GlobalVar.FrameCount = 0x04;
+        this->GlobalVar.MaxClients = 0x10;
+        this->GlobalVar.IntervalPerTick = 0x14;
+        this->GlobalVar.CurrentTime = 0x30;
+        this->GlobalVar.CurrentTime2 = 0x38;
+        this->GlobalVar.TickCount = 0x48;
+        this->GlobalVar.IntervalPerTick2 = 0x44;
+        this->GlobalVar.CurrentNetchan = 0x0048;
+        this->GlobalVar.CurrentMap = 0x0180;
+        this->GlobalVar.CurrentMapName = 0x0188;
 
-    this->WeaponBaseData.WeaponDataPTR = DWORD(client_dllJson["C_BaseEntity"]["fields"]["m_nSubclassID"]) + 0x08;
-    this->WeaponBaseData.szName = client_dllJson["CCSWeaponBaseVData"]["fields"]["m_szName"];
-    this->WeaponBaseData.Clip1 = client_dllJson["C_BasePlayerWeapon"]["fields"]["m_iClip1"];
-    this->WeaponBaseData.MaxClip = client_dllJson["CBasePlayerWeaponVData"]["fields"]["m_iMaxClip1"];
-    this->WeaponBaseData.Item = client_dllJson["C_AttributeContainer"]["fields"]["m_Item"];
-    this->WeaponBaseData.ItemDefinitionIndex = client_dllJson["C_EconItemView"]["fields"]["m_iItemDefinitionIndex"];
-    this->WeaponBaseData.hMyWeapons = client_dllJson["CPlayer_WeaponServices"]["fields"]["m_hMyWeapons"];
+        this->PlayerController.m_nTickBase = get_class_field("CBasePlayerController", "m_nTickBase");
+        this->PlayerController.m_steamID = get_class_field("CBasePlayerController", "m_steamID");
+        this->PlayerController.m_hPawn = get_class_field("CBasePlayerController", "m_hPawn");
+        this->PlayerController.m_pObserverServices = get_class_field("C_BasePlayerPawn", "m_pObserverServices");
+        this->PlayerController.m_hObserverTarget = get_class_field("CPlayer_ObserverServices", "m_hObserverTarget");
+        this->PlayerController.m_hController = get_class_field("C_BasePlayerPawn", "m_hController");
+        this->PlayerController.PawnArmor = get_class_field("CCSPlayerController", "m_iPawnArmor");
+        this->PlayerController.HasDefuser = get_class_field("CCSPlayerController", "m_bPawnHasDefuser");
+        this->PlayerController.HasHelmet = get_class_field("CCSPlayerController", "m_bPawnHasHelmet");
 
-    this->C4.m_bBeingDefused = client_dllJson["C_PlantedC4"]["fields"]["m_bBeingDefused"];
-    this->C4.m_flDefuseCountDown = client_dllJson["C_PlantedC4"]["fields"]["m_flDefuseCountDown"];
-    this->C4.m_nBombSite = client_dllJson["C_PlantedC4"]["fields"]["m_nBombSite"];
+        this->EconEntity.AttributeManager = get_class_field("C_EconEntity", "m_AttributeManager");
+
+        this->WeaponBaseData.WeaponDataPTR = get_class_field("C_BaseEntity", "m_nSubclassID") + 0x08;
+        this->WeaponBaseData.szName = get_class_field("CCSWeaponBaseVData", "m_szName");
+        this->WeaponBaseData.Clip1 = get_class_field("C_BasePlayerWeapon", "m_iClip1");
+        this->WeaponBaseData.MaxClip = get_class_field("CBasePlayerWeaponVData", "m_iMaxClip1");
+        this->WeaponBaseData.Item = get_class_field("C_AttributeContainer", "m_Item");
+        this->WeaponBaseData.ItemDefinitionIndex = get_class_field("C_EconItemView", "m_iItemDefinitionIndex");
+        this->WeaponBaseData.hMyWeapons = get_class_field("CPlayer_WeaponServices", "m_hMyWeapons");
+
+        this->C4.m_bBeingDefused = get_class_field("C_PlantedC4", "m_bBeingDefused");
+        this->C4.m_flDefuseCountDown = get_class_field("C_PlantedC4", "m_flDefuseCountDown");
+        this->C4.m_nBombSite = get_class_field("C_PlantedC4", "m_nBombSite");
+    }
+    catch (const std::exception& e) {
+        std::cout << "[X] Offset parsing error: " << e.what() << std::endl;
+    }
 }
 
 void Offsets::UpdateOffsets()
 {
     std::string offsets, buttons, client_dll;
-    std::string gameBuildNum = std::to_string
-    (
-        json::parse(Web::Get("https://raw.githubusercontent.com/sezzyaep/CS2-OFFSETS/refs/heads/main/info.json"))["build_number"]
-        .get<int>()
-    );
     
-    json GamaDataStorage;
+    bool forceUpdate = false;
+    std::string dataPath = MenuConfig::path + "\\Data\\";
+    
     try
     {
-        GamaDataStorage = json::parse(storage::ReadStorageFile("gamedata.json"));
-    }
-    catch(...)
-    {
-        GamaDataStorage = json::object();
-    }
-
-    try
-    {
-        if (gameBuildNum.find(GamaDataStorage["build-number"].get<std::string>()) == std::string::npos)
-            throw std::runtime_error("cloud offsets got updated");
-
-        offsets = storage::ReadStorageFile("offsets.json");
-        buttons = storage::ReadStorageFile("buttons.json");
-        client_dll = storage::ReadStorageFile("client_dll.json");
+        if (!storage::FileExists("offsets.json") || !storage::FileExists("buttons.json") || !storage::FileExists("client_dll.json"))
+        {
+            forceUpdate = true;
+        }
+        else
+        {
+            // Check if files are older than 12 hours
+            auto now = std::filesystem::file_time_type::clock::now();
+            auto lastWrite = std::filesystem::last_write_time(dataPath + "offsets.json");
+            auto age = std::chrono::duration_cast<std::chrono::hours>(now - lastWrite).count();
+            
+            if (age >= 12)
+                forceUpdate = true;
+        }
     }
     catch (...)
     {
-        offsets = Web::Get("https://raw.githubusercontent.com/sezzyaep/CS2-OFFSETS/refs/heads/main/offsets.json");
-        buttons = Web::Get("https://raw.githubusercontent.com/sezzyaep/CS2-OFFSETS/refs/heads/main/buttons.json");
-        client_dll = Web::Get("https://raw.githubusercontent.com/sezzyaep/CS2-OFFSETS/refs/heads/main/client_dll.json");
+        forceUpdate = true;
+    }
+
+    try
+    {
+        if (!forceUpdate)
+        {
+            offsets = storage::ReadStorageFile("offsets.json");
+            buttons = storage::ReadStorageFile("buttons.json");
+            client_dll = storage::ReadStorageFile("client_dll.json");
+        }
+        else
+        {
+            throw std::runtime_error("force update");
+        }
+    }
+    catch (...)
+    {
+        std::cout << "[i] Downloading latest offsets from cloud..." << std::endl;
+        
+        offsets = Web::Get("https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/offsets.json");
+        buttons = Web::Get("https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/buttons.json");
+        client_dll = Web::Get("https://raw.githubusercontent.com/a2x/cs2-dumper/main/output/client_dll.json");
 
         storage::WriteStorageFile("offsets.json", offsets);
         storage::WriteStorageFile("buttons.json", buttons);
         storage::WriteStorageFile("client_dll.json", client_dll);
-
-        GamaDataStorage["build-number"] = gameBuildNum;
-        storage::WriteStorageFile("gamedata.json", GamaDataStorage.dump(4));
+        
+        std::cout << "[+] Offsets updated successfully" << std::endl;
     }
     SetOffsets(offsets, buttons, client_dll);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### General

- Related issue: Fixed "json.exception.type_error.302" on startup.
- Related functionality: Automatic offset updates.
- Feature in todo: Yes
- Should be documented: No

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

### Type

- [X] Bugfix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [X] Regular code maintenance
- [ ] Tests-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

### Description

Updated the offset provider from the unmaintained sezzyaep/CS2-OFFSETS repository to the community standard a2x/cs2-dumper. Refactored SetOffsets in Offsets.cpp to use a more robust parsing method that handles missing or null fields gracefully instead of throwing JSON exceptions. Added a time-based update check (12 hours) in UpdateOffsets to ensure local data stays synchronized with game updates. Also implemented storage::FileExists in StorageMgr for cleaner file handling.

### Effect

This change restores the core functionality of the cheat by fixing the crash at startup caused by outdated or missing offsets. It ensures the cheat remains compatible with future CS2 updates by pulling data from a frequently updated source. 
The update logic is now more intelligent and doesn't rely on the non-existent info.json file from the previous provider.

## Other information

The new logic uses std::filesystem::last_write_time to check file age. This removes the need for manual data folder deletion when offsets are updated on GitHub. The SetOffsets function now logs parsing errors to the console instead of crashing, making future debugging much easier for contributors.
